### PR TITLE
Backport fix for missing jmx

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,12 @@
-/.project
+# Eclipse
+.project
+.settings
+.classpath
+
+# IntelliJ
 /.idea
 **/*.iml
+
+# Maven
 **/target
-/target/
-/.settings
+target/

--- a/README.md
+++ b/README.md
@@ -1,0 +1,6 @@
+  
+# Changelog
+
+
+*   backporting fix for missing jmx classes within android - similar to [LOG4J2-1051](https://issues.apache.org/jira/browse/LOG4J2-1051) within Google App Engine
+ 

--- a/log4j-bom/.gitignore
+++ b/log4j-bom/.gitignore
@@ -1,2 +1,0 @@
-/target/
-/.project

--- a/log4j-core/src/main/java/org/apache/logging/log4j/core/lookup/Interpolator.java
+++ b/log4j-core/src/main/java/org/apache/logging/log4j/core/lookup/Interpolator.java
@@ -33,6 +33,12 @@ import org.apache.logging.log4j.status.StatusLogger;
  */
 public class Interpolator extends AbstractLookup {
 
+    private static final String LOOKUP_KEY_WEB = "web";
+
+    private static final String LOOKUP_KEY_JNDI = "jndi";
+
+    private static final String LOOKUP_KEY_JVMRUNARGS = "jvmrunargs";
+
     private static final Logger LOGGER = StatusLogger.getLogger();
 
     /** Constant for the prefix separator. */
@@ -63,8 +69,8 @@ public class Interpolator extends AbstractLookup {
             try {
                 final Class<? extends StrLookup> clazz = entry.getValue().getPluginClass().asSubclass(StrLookup.class);
                 lookups.put(entry.getKey(), ReflectionUtil.instantiate(clazz));
-            } catch (final Exception ex) {
-                LOGGER.error("Unable to create Lookup for {}", entry.getKey(), ex);
+            } catch (final Throwable t) {
+                handleError(entry.getKey(), t);
             }
         }
     }
@@ -89,41 +95,53 @@ public class Interpolator extends AbstractLookup {
         // JNDI
         try {
             // [LOG4J2-703] We might be on Android
-            lookups.put("jndi",
+            lookups.put(LOOKUP_KEY_JNDI,
                 Loader.newCheckedInstanceOf("org.apache.logging.log4j.core.lookup.JndiLookup", StrLookup.class));
         } catch (final Throwable e) {
-            // java.lang.VerifyError: org/apache/logging/log4j/core/lookup/JndiLookup
-            LOGGER.warn(
-                    "JNDI lookup class is not available because this JRE does not support JNDI. JNDI string lookups will not be available, continuing configuration.",
-                    e);
+            handleError(LOOKUP_KEY_JNDI, e);
         }
         // JMX input args
         try {
             // We might be on Android
-            lookups.put("jvmrunargs",
+            lookups.put(LOOKUP_KEY_JVMRUNARGS,
                 Loader.newCheckedInstanceOf("org.apache.logging.log4j.core.lookup.JmxRuntimeInputArgumentsLookup", StrLookup.class));
         } catch (final Throwable e) {
-            // java.lang.VerifyError: org/apache/logging/log4j/core/lookup/JmxRuntimeInputArgumentsLookup
-            LOGGER.warn(
-                    "JMX runtime input lookup class is not available because this JRE does not support JMX. JMX lookups will not be available, continuing configuration.",
-                    e);
+            handleError(LOOKUP_KEY_JVMRUNARGS, e);
         }
         lookups.put("date", new DateLookup());
         lookups.put("ctx", new ContextMapLookup());
         if (Loader.isClassAvailable("javax.servlet.ServletContext")) {
             try {
-                lookups.put("web",
+                lookups.put(LOOKUP_KEY_WEB,
                     Loader.newCheckedInstanceOf("org.apache.logging.log4j.web.WebLookup", StrLookup.class));
             } catch (final Exception ignored) {
-                LOGGER.info("Log4j appears to be running in a Servlet environment, but there's no log4j-web module " +
-                    "available. If you want better web container support, please add the log4j-web JAR to your " +
-                    "web archive or server lib directory.");
+                handleError(LOOKUP_KEY_WEB, ignored);
             }
         } else {
             LOGGER.debug("Not in a ServletContext environment, thus not loading WebLookup plugin.");
         }
     }
 
+    private void handleError(final String lookupKey, final Throwable t) {
+        if(LOOKUP_KEY_JNDI.equals(lookupKey)) {
+            // java.lang.VerifyError: org/apache/logging/log4j/core/lookup/JndiLookup
+            LOGGER.warn( // LOG4J2-1582 don't print the whole stack trace (it is just a warning...)
+                    "JNDI lookup class is not available because this JRE does not support JNDI." +
+                    " JNDI string lookups will not be available, continuing configuration. Ignoring " + t);
+        } else if(LOOKUP_KEY_JVMRUNARGS.equals(lookupKey)) {
+            // java.lang.VerifyError: org/apache/logging/log4j/core/lookup/JmxRuntimeInputArgumentsLookup
+            LOGGER.warn(
+                    "JMX runtime input lookup class is not available because this JRE does not support JMX. " +
+                    "JMX lookups will not be available, continuing configuration. Ignoring " + t);
+        } else if(LOOKUP_KEY_WEB.equals(lookupKey)) {
+            LOGGER.info("Log4j appears to be running in a Servlet environment, but there's no log4j-web module " +
+                    "available. If you want better web container support, please add the log4j-web JAR to your " +
+                    "web archive or server lib directory.");
+        } else {
+            LOGGER.error("Unable to create Lookup for {}", lookupKey, t);
+        }
+    }
+    
     /**
      * Resolves the specified variable. This implementation will try to extract
      * a variable prefix from the given variable name (the first colon (':') is


### PR DESCRIPTION
Under android there is no jmx. In version Log4j 2.3 leads this to an exception while the current version 2.7 knows how to deal with this.
For Android < API 19 I need to take version 2.3 so I backported this fix into Interpolator class.